### PR TITLE
Added the ability to select a contact and view their details

### DIFF
--- a/src/app/pages/ContactListScreen/ContactListScreen.jsx
+++ b/src/app/pages/ContactListScreen/ContactListScreen.jsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { Component } from 'react';
 import {
   string,
   arrayOf,
+  func,
+  number,
   shape,
 } from 'prop-types';
 
@@ -11,20 +13,58 @@ import ButtonAction from '../../../framework/util/ButtonAction';
 import Contact from './components/Contact/Contact';
 import './contact_list.css';
 
-export const ContactListScreen = ({ contacts }) => {
-  return (
-    <div id='contact-screen' className='contact-screen'>
-      <h1 className='title'>Contacts</h1>
-      <GenericList
-        className='contacts-list'
-        items={ contacts }
-        listItem={ Contact }
-      />
-    </div>
-  );
-};
+export class ContactListComponent extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { selectedContactIndex: props.selectedContactIndex };
+  }
 
-ContactListScreen.propTypes = {
+  componentDidMount() {
+    this.props.remapButtons(this.buttonActions);
+  }
+
+  componentDidUpdate() {
+    this.props.remapButtons(this.buttonActions);
+  }
+
+  selectNextContact() {
+    if (this.state.selectedContactIndex < this.props.contacts.length - 1) {
+      this.setState({ selectedContactIndex: ++this.state.selectedContactIndex });
+    }
+  }
+
+  selectPreviousContact() {
+    if (this.state.selectedContactIndex > 0) {
+      this.setState({ selectedContactIndex: --this.state.selectedContactIndex });
+    }
+  }
+
+  buttonActions = {
+    RIGHT: () => ButtonAction.goToPage('/counter'),
+    LEFT: () => ButtonAction.goToPage('/'),
+    BOTTOM: () => { ButtonAction.scrollDown(); this.selectNextContact(); },
+    TOP: () => { ButtonAction.scrollUp(); this.selectPreviousContact(); },
+    SCREEN: () => ButtonAction.goToPage(`/contact/${ this.state.selectedContactIndex }`),
+  };
+
+  render() {
+    return (
+      <div id='contact-screen' className='contact-screen'>
+        <h1 className='title'>Contacts</h1>
+        <GenericList
+          className='contacts-list'
+          items={ this.props.contacts }
+          selectedItemIndex={ this.state.selectedContactIndex }
+          listItem={ Contact }
+        />
+      </div>
+    );
+  }
+}
+
+ContactListComponent.propTypes = {
+  selectedContactIndex: number.isRequired,
+  remapButtons: func.isRequired,
   contacts: arrayOf(shape({
     name: string,
     phone: string,
@@ -32,11 +72,9 @@ ContactListScreen.propTypes = {
   })).isRequired,
 };
 
-export const ContactScreenButtons = {
-  LEFT: () => ButtonAction.goToPage('/'),
-  RIGHT: () => ButtonAction.goToPage('/counter'),
-  TOP: () => ButtonAction.scrollUp(),
-  BOTTOM: () => ButtonAction.scrollDown(),
+ContactListComponent.defaultProps = {
+  selectedContactIndex: 0,
 };
 
-export default WithButtonConfigs(ContactListScreen, ContactScreenButtons);
+
+export default WithButtonConfigs(ContactListComponent);

--- a/src/app/pages/ContactListScreen/contact_list.css
+++ b/src/app/pages/ContactListScreen/contact_list.css
@@ -4,6 +4,8 @@
 
 .contact-screen .contacts-list ul {
   padding-bottom: 5px;
-
 }
 
+.contact-screen li.selected {
+  background-color: rgba(153, 153, 153, 0.21);
+}

--- a/src/app/pages/ContactViewScreen/ContactViewScreen.js
+++ b/src/app/pages/ContactViewScreen/ContactViewScreen.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import {
+  string,
+  arrayOf,
+  number,
+  shape,
+} from 'prop-types';
+import { withRouter } from 'react-router';
+import ButtonAction from '../../../framework/util/ButtonAction';
+import WithButtonConfigs from '../../../framework/containers/WithButtonConfigs';
+
+export const ContactViewScreenComponent = ({ contacts, match }) => {
+  const selectedContact = contacts[match.params.selectedContactIndex];
+  return (
+    <div className='contact'>
+      <h2> Yay here is your contact </h2>
+      <div className='name'>
+        <b>Name</b>: {selectedContact.name}
+      </div>
+    </div>
+  );
+};
+
+ContactViewScreenComponent.propTypes = {
+  match: shape({ params: shape({ selectedContactIndex: number.isRequired }) }).isRequired,
+  contacts: arrayOf(shape({
+    name: string,
+    phone: string,
+    address: string,
+  })).isRequired,
+};
+
+export const ContactViewScreenButtons = {
+  LEFT: () => ButtonAction.goToPage({ pathname: '/counter', state: { number: 5 } }),
+  RIGHT: () => ButtonAction.goToPage('/contacts'),
+  TOP: () => ButtonAction.scrollUp(),
+  BOTTOM: () => ButtonAction.scrollDown(),
+};
+
+export default withRouter(WithButtonConfigs(ContactViewScreenComponent, ContactViewScreenButtons));

--- a/src/app/pages/ContactViewScreen/ContactViewScreen.spec.js
+++ b/src/app/pages/ContactViewScreen/ContactViewScreen.spec.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ButtonAction from '../../../framework/util/ButtonAction';
+import { ContactViewScreenComponent as ContactViewScreen, ContactViewScreenButtons } from './ContactViewScreen';
+
+jest.mock('../../../framework/util/ButtonAction');
+
+describe('ContactViewScreen ', () => {
+  let componentWrapper;
+  const mockContacts = [{ name: 'contact 0' }, { name: 'MeMeMEEE' }];
+  const mockRouterMatchObj = { params: { selectedContactIndex: 1 } };
+
+  beforeEach(() => {
+    componentWrapper = shallow(
+      <ContactViewScreen contacts={ mockContacts } match={ mockRouterMatchObj } />
+    );
+  });
+
+  it('should have a header', () => {
+    expect(componentWrapper.find('h2')).toBePresent();
+  });
+
+  it('should display the required contact based on the url path', () => {
+    expect(componentWrapper.find('.name')).toHaveText('Name: MeMeMEEE');
+  });
+
+  test('it should have a LEFT button config of going to Counter Page with an initial number value of 5', () => {
+    ContactViewScreenButtons.LEFT();
+    expect(ButtonAction.goToPage).toHaveBeenCalledWith({ pathname: '/counter', state: { number: 5 } });
+  });
+
+  test('it should have a RIGHT button config of going to contactList page', () => {
+    ContactViewScreenButtons.RIGHT();
+    expect(ButtonAction.goToPage).toHaveBeenCalledWith('/contacts');
+  });
+
+  test('it should have a TOP button config of scrolling page up', () => {
+    ContactViewScreenButtons.TOP();
+    expect(ButtonAction.scrollUp).toHaveBeenCalled();
+  });
+
+  test('it should have a BOTTOM button config of scrolling page down', () => {
+    ContactViewScreenButtons.BOTTOM();
+    expect(ButtonAction.scrollDown).toHaveBeenCalled();
+  });
+});

--- a/src/framework/components/GenericList/GenericList.jsx
+++ b/src/framework/components/GenericList/GenericList.jsx
@@ -7,6 +7,7 @@ const GenericList = (props) => {
     liClassName,
     items,
     listItem,
+    selectedItemIndex,
   } = props;
 
   return (
@@ -14,7 +15,7 @@ const GenericList = (props) => {
       {items.map((item, index) => (
         <li
           key={ `generic-list-${ index + 1 }` }
-          className={ liClassName }
+          className={ `${ liClassName } ${ index === selectedItemIndex ? 'selected' : '' }` }
         >
           {listItem(item)}
         </li>
@@ -26,6 +27,7 @@ const GenericList = (props) => {
 GenericList.propTypes = {
   className: PropTypes.string,
   liClassName: PropTypes.string,
+  selectedItemIndex: PropTypes.number,
   items: PropTypes.arrayOf(PropTypes.any).isRequired,
   listItem: PropTypes.func.isRequired,
 };
@@ -33,6 +35,7 @@ GenericList.propTypes = {
 GenericList.defaultProps = {
   className: 'generic-list',
   liClassName: '',
+  selectedItemIndex: 0,
   items: [],
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import HomeScreen from './app/pages/HomeScreen/HomeScreen';
 import CounterScreen from './app/pages/CounterScreen/CounterScreen';
 import ContactScreen from './app/pages/ContactListScreen/ContactListScreen';
+import ContactViewScreen from './app/pages/ContactViewScreen/ContactViewScreen';
 import NotFoundScreen from './app/pages/NotFoundScreen/NotFoundScreen';
 import contacts from './app/data/contacts.json';
 import WatchApp from './framework';
@@ -11,6 +12,7 @@ import WatchApp from './framework';
 const pages = [
   { path: '/', Component: HomeScreen },
   { path: '/contacts', Component: ContactScreen, props: { contacts } },
+  { path: '/contact/:selectedContactIndex', Component: ContactViewScreen, props: { contacts } },
   { path: '/counter', Component: CounterScreen },
   { path: '/notfound', Component: NotFoundScreen },
 ];


### PR DESCRIPTION
@raytung  @adamhope  @AMitchemTW  @aaron-m-edwards This is a quick spike to mimic the previous menu selection page. I refactored the contact list screen to make it stateful and store the index of a specific item in the list based on the top and bottom buttons. When you press on the screen it will then pass the index to the new contactView page which will display the contact's details

Please note:
It's not the cleanest solution and it's currently all spiked up using the client code rather than the framework. Not sure if we want to make it an HOC and use Redux as it might confuse students even more. They already have a hard time trying to understand how the button remapping works, so not sure if we want to move everything to Redux. Feel free to modify it and make it cleaner.