### PR TITLE
Added the ability to select a contact and view their details (rework of #28)

### DIFF
--- a/src/app/pages/ContactListScreen/ContactListScreen.jsx
+++ b/src/app/pages/ContactListScreen/ContactListScreen.jsx
@@ -17,10 +17,6 @@ export class ContactListComponent extends Component {
     this.props.remapButtons(this.buttonActions);
   }
 
-  componentDidUpdate() {
-    this.props.remapButtons(this.buttonActions);
-  }
-
   selectNextContact() {
     if (this.props.selectedIndex < this.props.contacts.length - 1) {
       ButtonAction.goToPage({ state: { selectedIndex: this.props.selectedIndex + 1 } });

--- a/src/app/pages/ContactListScreen/ContactListScreen.jsx
+++ b/src/app/pages/ContactListScreen/ContactListScreen.jsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { Component } from 'react';
 import {
   string,
   arrayOf,
+  func,
+  number,
   shape,
 } from 'prop-types';
 
@@ -11,20 +13,58 @@ import ButtonAction from '../../../framework/util/ButtonAction';
 import Contact from './components/Contact/Contact';
 import './contact_list.css';
 
-export const ContactListScreen = ({ contacts }) => {
-  return (
-    <div id='contact-screen' className='contact-screen'>
-      <h1 className='title'>Contacts</h1>
-      <GenericList
-        className='contacts-list'
-        items={ contacts }
-        listItem={ Contact }
-      />
-    </div>
-  );
-};
+export class ContactListComponent extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { selectedContactIndex: props.selectedContactIndex };
+  }
 
-ContactListScreen.propTypes = {
+  componentDidMount() {
+    this.props.remapButtons(this.buttonActions);
+  }
+
+  componentDidUpdate() {
+    this.props.remapButtons(this.buttonActions);
+  }
+
+  selectNextContact() {
+    if (this.state.selectedContactIndex < this.props.contacts.length - 1) {
+      this.setState({ selectedContactIndex: ++this.state.selectedContactIndex });
+    }
+  }
+
+  selectPreviousContact() {
+    if (this.state.selectedContactIndex > 0) {
+      this.setState({ selectedContactIndex: --this.state.selectedContactIndex });
+    }
+  }
+
+  buttonActions = {
+    RIGHT: () => ButtonAction.goToPage('/counter'),
+    LEFT: () => ButtonAction.goToPage('/'),
+    BOTTOM: () => { ButtonAction.scrollDown(); this.selectNextContact(); },
+    TOP: () => { ButtonAction.scrollUp(); this.selectPreviousContact(); },
+    SCREEN: () => ButtonAction.goToPage(`/contact/${ this.state.selectedContactIndex }`),
+  };
+
+  render() {
+    return (
+      <div id='contact-screen' className='contact-screen'>
+        <h1 className='title'>Contacts</h1>
+        <GenericList
+          className='contacts-list'
+          items={ this.props.contacts }
+          selectedItemIndex={ this.state.selectedContactIndex }
+          listItem={ Contact }
+        />
+      </div>
+    );
+  }
+}
+
+ContactListComponent.propTypes = {
+  selectedContactIndex: number.isRequired,
+  remapButtons: func.isRequired,
   contacts: arrayOf(shape({
     name: string,
     phone: string,
@@ -32,11 +72,9 @@ ContactListScreen.propTypes = {
   })).isRequired,
 };
 
-export const ContactScreenButtons = {
-  LEFT: () => ButtonAction.goToPage('/'),
-  RIGHT: () => ButtonAction.goToPage('/counter'),
-  TOP: () => ButtonAction.scrollUp(),
-  BOTTOM: () => ButtonAction.scrollDown(),
+ContactListComponent.defaultProps = {
+  selectedContactIndex: 0,
 };
 
-export default WithButtonConfigs(ContactListScreen, ContactScreenButtons);
+
+export default WithButtonConfigs(ContactListComponent);

--- a/src/app/pages/ContactListScreen/ContactListScreen.jsx
+++ b/src/app/pages/ContactListScreen/ContactListScreen.jsx
@@ -7,18 +7,12 @@ import {
   shape,
 } from 'prop-types';
 
-import GenericList from '../../../framework/components/GenericList/GenericList';
+import ScrollList from '../../../framework/components/ScrollList/ScrollList';
 import WithButtonConfigs from '../../../framework/containers/WithButtonConfigs';
 import ButtonAction from '../../../framework/util/ButtonAction';
-import Contact from './components/Contact/Contact';
 import './contact_list.css';
 
 export class ContactListComponent extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { selectedContactIndex: props.selectedContactIndex };
-  }
-
   componentDidMount() {
     this.props.remapButtons(this.buttonActions);
   }
@@ -28,34 +22,35 @@ export class ContactListComponent extends Component {
   }
 
   selectNextContact() {
-    if (this.state.selectedContactIndex < this.props.contacts.length - 1) {
-      this.setState({ selectedContactIndex: ++this.state.selectedContactIndex });
+    if (this.props.selectedIndex < this.props.contacts.length - 1) {
+      ButtonAction.goToPage({ state: { selectedIndex: this.props.selectedIndex + 1 } });
     }
   }
 
   selectPreviousContact() {
-    if (this.state.selectedContactIndex > 0) {
-      this.setState({ selectedContactIndex: --this.state.selectedContactIndex });
+    if (this.props.selectedIndex > 0) {
+      ButtonAction.goToPage({ state: { selectedIndex: this.props.selectedIndex - 1 } });
     }
   }
 
   buttonActions = {
     RIGHT: () => ButtonAction.goToPage('/counter'),
     LEFT: () => ButtonAction.goToPage('/'),
-    BOTTOM: () => { ButtonAction.scrollDown(); this.selectNextContact(); },
-    TOP: () => { ButtonAction.scrollUp(); this.selectPreviousContact(); },
-    SCREEN: () => ButtonAction.goToPage(`/contact/${ this.state.selectedContactIndex }`),
+    BOTTOM: () => { this.selectNextContact(); },
+    TOP: () => { this.selectPreviousContact(); },
+    SCREEN: () => ButtonAction.goToPage({
+      pathname: '/contact-view',
+      state: { contact: this.props.contacts[this.props.selectedIndex] },
+    }),
   };
 
   render() {
     return (
       <div id='contact-screen' className='contact-screen'>
         <h1 className='title'>Contacts</h1>
-        <GenericList
-          className='contacts-list'
-          items={ this.props.contacts }
-          selectedItemIndex={ this.state.selectedContactIndex }
-          listItem={ Contact }
+        <ScrollList
+          labels={ this.props.contacts.map(c => c.name) }
+          selectedIndex={ this.props.selectedIndex }
         />
       </div>
     );
@@ -63,7 +58,7 @@ export class ContactListComponent extends Component {
 }
 
 ContactListComponent.propTypes = {
-  selectedContactIndex: number.isRequired,
+  selectedIndex: number,
   remapButtons: func.isRequired,
   contacts: arrayOf(shape({
     name: string,
@@ -73,7 +68,7 @@ ContactListComponent.propTypes = {
 };
 
 ContactListComponent.defaultProps = {
-  selectedContactIndex: 0,
+  selectedIndex: 0,
 };
 
 

--- a/src/app/pages/ContactListScreen/ContactListScreen.jsx
+++ b/src/app/pages/ContactListScreen/ContactListScreen.jsx
@@ -23,7 +23,7 @@ export const ContactListComponent = ({ contacts, selectedIndex }) => (
 
 const getNextIndex = (indexChange, selectedIndex, contacts) => {
   const newIndex = selectedIndex + indexChange;
-  return Math.abs(newIndex % contacts.length);
+  return Math.abs((newIndex + contacts.length) % contacts.length);
 };
 
 export const buttonActions = ({ contacts, selectedIndex = 0 }) => ({

--- a/src/app/pages/ContactListScreen/ContactListScreen.jsx
+++ b/src/app/pages/ContactListScreen/ContactListScreen.jsx
@@ -1,8 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import {
   string,
   arrayOf,
-  func,
   number,
   shape,
 } from 'prop-types';
@@ -12,56 +11,40 @@ import WithButtonConfigs from '../../../framework/containers/WithButtonConfigs';
 import ButtonAction from '../../../framework/util/ButtonAction';
 import './contact_list.css';
 
-export class ContactListComponent extends Component {
-  componentDidMount() {
-    this.props.remapButtons(this.buttonActions);
-  }
+export const ContactListComponent = ({ contacts, selectedIndex }) => (
+  <div id='contact-screen' className='contact-screen'>
+    <h1 className='title'>Contacts</h1>
+    <ScrollList
+      labels={ contacts.map(c => c.name) }
+      selectedIndex={ selectedIndex }
+    />
+  </div>
+);
 
-  getNextIndex = (indexChange) => {
-    const { selectedIndex, contacts } = this.props;
-    const newIndex = selectedIndex + indexChange;
-    return Math.abs(newIndex % contacts.length);
-  }
+const getNextIndex = (indexChange, selectedIndex, contacts) => {
+  const newIndex = selectedIndex + indexChange;
+  return Math.abs(newIndex % contacts.length);
+};
 
-  selectNextContact() {
-    ButtonAction.goToPage({ state: { selectedIndex: this.getNextIndex(1) } });
-  }
-
-  selectPreviousContact() {
-    ButtonAction.goToPage({ state: { selectedIndex: this.getNextIndex(-1) } });
-  }
-
-  buttonActions = {
-    RIGHT: () => ButtonAction.goToPage('/counter'),
-    LEFT: () => ButtonAction.goToPage('/'),
-    BOTTOM: () => { this.selectNextContact(); },
-    TOP: () => { this.selectPreviousContact(); },
-    SCREEN: () => ButtonAction.goToPage({
-      pathname: '/contact-view',
-      state: { contact: this.props.contacts[this.props.selectedIndex] },
-    }),
-  };
-
-  render() {
-    return (
-      <div id='contact-screen' className='contact-screen'>
-        <h1 className='title'>Contacts</h1>
-        <ScrollList
-          labels={ this.props.contacts.map(c => c.name) }
-          selectedIndex={ this.props.selectedIndex }
-        />
-      </div>
-    );
-  }
-}
+export const buttonActions = ({ contacts, selectedIndex = 0 }) => ({
+  RIGHT: () => ButtonAction.goToPage('/counter'),
+  LEFT: () => ButtonAction.goToPage('/'),
+  BOTTOM: () => {
+    ButtonAction.goToPage({ state: { selectedIndex: getNextIndex(1, selectedIndex, contacts) } });
+  },
+  TOP: () => {
+    ButtonAction.goToPage({ state: { selectedIndex: getNextIndex(-1, selectedIndex, contacts) } });
+  },
+  SCREEN: () => ButtonAction.goToPage({
+    pathname: '/contact-view',
+    state: { contact: contacts[selectedIndex] },
+  }),
+});
 
 ContactListComponent.propTypes = {
   selectedIndex: number,
-  remapButtons: func.isRequired,
   contacts: arrayOf(shape({
     name: string,
-    phone: string,
-    address: string,
   })).isRequired,
 };
 
@@ -70,4 +53,4 @@ ContactListComponent.defaultProps = {
 };
 
 
-export default WithButtonConfigs(ContactListComponent);
+export default WithButtonConfigs(ContactListComponent, buttonActions);

--- a/src/app/pages/ContactListScreen/ContactListScreen.jsx
+++ b/src/app/pages/ContactListScreen/ContactListScreen.jsx
@@ -17,16 +17,18 @@ export class ContactListComponent extends Component {
     this.props.remapButtons(this.buttonActions);
   }
 
+  getNextIndex = (indexChange) => {
+    const { selectedIndex, contacts } = this.props;
+    const newIndex = selectedIndex + indexChange;
+    return Math.abs(newIndex % contacts.length);
+  }
+
   selectNextContact() {
-    if (this.props.selectedIndex < this.props.contacts.length - 1) {
-      ButtonAction.goToPage({ state: { selectedIndex: this.props.selectedIndex + 1 } });
-    }
+    ButtonAction.goToPage({ state: { selectedIndex: this.getNextIndex(1) } });
   }
 
   selectPreviousContact() {
-    if (this.props.selectedIndex > 0) {
-      ButtonAction.goToPage({ state: { selectedIndex: this.props.selectedIndex - 1 } });
-    }
+    ButtonAction.goToPage({ state: { selectedIndex: this.getNextIndex(-1) } });
   }
 
   buttonActions = {

--- a/src/app/pages/ContactListScreen/ContactListScreen.spec.js
+++ b/src/app/pages/ContactListScreen/ContactListScreen.spec.js
@@ -11,7 +11,7 @@ describe('ContactListScreen component', () => {
     jest.resetAllMocks();
 
     defaultProps = {
-      contacts: [{ name: 'contact 1' }, { name: 'contact 2' }],
+      contacts: [{ name: 'contact 1' }, { name: 'contact 2' }, { name: 'contact 3' }],
       selectedIndex: 0,
     };
   });
@@ -48,17 +48,17 @@ describe('ContactListScreen component', () => {
 
     describe('TOP button', () => {
       it('should set previous contact', () => {
-        buttonActions({ ...defaultProps, selectedIndex: 1 }).TOP();
+        buttonActions({ ...defaultProps, selectedIndex: 2 }).TOP();
 
         expect(ButtonAction.goToPage).toHaveBeenCalledWith({
-          state: { selectedIndex: 0 },
+          state: { selectedIndex: 1 },
         });
       });
       it('should roll back to the bottom', () => {
         buttonActions({ ...defaultProps, selectedIndex: 0 }).TOP();
 
         expect(ButtonAction.goToPage).toHaveBeenCalledWith({
-          state: { selectedIndex: 1 },
+          state: { selectedIndex: 2 },
         });
       });
     });
@@ -73,7 +73,7 @@ describe('ContactListScreen component', () => {
       });
 
       it('should roll back to the top', () => {
-        buttonActions({ ...defaultProps, selectedIndex: 1 }).BOTTOM();
+        buttonActions({ ...defaultProps, selectedIndex: 2 }).BOTTOM();
 
         expect(ButtonAction.goToPage).toHaveBeenCalledWith({
           state: { selectedIndex: 0 },

--- a/src/app/pages/ContactListScreen/ContactListScreen.spec.js
+++ b/src/app/pages/ContactListScreen/ContactListScreen.spec.js
@@ -9,9 +9,13 @@ describe('ContactListScreen component', () => {
   let componentWrapper;
   let onLoadRemapButtons;
   beforeEach(() => {
+    jest.resetAllMocks();
     onLoadRemapButtons = jest.fn();
     componentWrapper = mount(
-      <ContactListScreen contacts={ [{ name: 'bleh' }, { name: 'bloh' }] } remapButtons={ onLoadRemapButtons } />
+      <ContactListScreen
+        contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
+        remapButtons={ onLoadRemapButtons }
+      />
     );
   });
 
@@ -24,7 +28,7 @@ describe('ContactListScreen component', () => {
   });
 
   it('should contain a GenericList component', () => {
-    expect(componentWrapper.find('GenericList')).toBePresent();
+    expect(componentWrapper.find('ScrollList')).toBePresent();
   });
 
   it('should have a LEFT button config of going to Home Page', () => {
@@ -38,48 +42,73 @@ describe('ContactListScreen component', () => {
   });
 
   it('should have on SCREEN button config of going to contact view page with the selected contact', () => {
-    componentWrapper.instance().setState({ selectedContactIndex: 2 });
+    componentWrapper = mount(
+      <ContactListScreen
+        contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
+        remapButtons={ onLoadRemapButtons }
+        selectedIndex={ 1 }
+      />
+    );
+
     componentWrapper.instance().buttonActions.SCREEN();
-    expect(ButtonAction.goToPage).toHaveBeenCalledWith('/contact/2');
+
+    expect(ButtonAction.goToPage).toHaveBeenCalledWith({
+      pathname: '/contact-view',
+      state: { contact: { name: 'bloh' } },
+    });
   });
 
   describe('TOP button', () => {
-    it('should scrolling up', () => {
-      componentWrapper.instance().buttonActions.TOP();
-      expect(ButtonAction.scrollUp).toHaveBeenCalled();
-    });
-
     it('should set previous contact in state', () => {
-      componentWrapper.instance().setState({ selectedContactIndex: 2 });
+      componentWrapper = mount(
+        <ContactListScreen
+          contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
+          remapButtons={ onLoadRemapButtons }
+          selectedIndex={ 1 }
+        />
+      );
       componentWrapper.instance().buttonActions.TOP();
-      expect(componentWrapper.instance().state.selectedContactIndex).toBe(1);
+      expect(ButtonAction.goToPage).toHaveBeenCalledWith({ state: { selectedIndex: 0 } });
     });
 
     it('should set the selected contact index in negative', () => {
-      componentWrapper.instance().setState({ selectedContactIndex: 1 });
+      componentWrapper = mount(
+        <ContactListScreen
+          contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
+          remapButtons={ onLoadRemapButtons }
+          selectedIndex={ 0 }
+        />
+      );
       componentWrapper.instance().buttonActions.TOP();
-      componentWrapper.instance().buttonActions.TOP();
-      componentWrapper.instance().buttonActions.TOP();
-      expect(componentWrapper.instance().state.selectedContactIndex).toBe(0);
+      expect(ButtonAction.goToPage).not.toHaveBeenCalled();
     });
   });
 
   describe('BOTTOM button', () => {
-    it('should  scrolling down', () => {
-      componentWrapper.instance().buttonActions.BOTTOM();
-      expect(ButtonAction.goToPage).toHaveBeenCalled();
-    });
-
     it('should set next contact in state', () => {
+      componentWrapper = mount(
+        <ContactListScreen
+          contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
+          remapButtons={ onLoadRemapButtons }
+          selectedIndex={ 0 }
+        />
+      );
       componentWrapper.instance().buttonActions.BOTTOM();
-      expect(componentWrapper.instance().state.selectedContactIndex).toBe(1);
+      expect(ButtonAction.goToPage).toHaveBeenCalledWith({ state: { selectedIndex: 1 } });
     });
 
     it('should set selected contact index to be more than the contact list length', () => {
+      componentWrapper = mount(
+        <ContactListScreen
+          contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
+          remapButtons={ onLoadRemapButtons }
+          selectedIndex={ 1 }
+        />
+      );
+
       componentWrapper.instance().buttonActions.BOTTOM();
-      componentWrapper.instance().buttonActions.BOTTOM();
-      componentWrapper.instance().buttonActions.BOTTOM();
-      expect(componentWrapper.instance().state.selectedContactIndex).toBe(1);
+
+      expect(ButtonAction.goToPage).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/pages/ContactListScreen/ContactListScreen.spec.js
+++ b/src/app/pages/ContactListScreen/ContactListScreen.spec.js
@@ -1,134 +1,92 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import { ContactListComponent as ContactListScreen } from './ContactListScreen';
+import { shallow } from 'enzyme';
+import { ContactListComponent, buttonActions } from './ContactListScreen';
 import ButtonAction from '../../../framework/util/ButtonAction';
 
 jest.mock('../../../framework/util/ButtonAction');
 
 describe('ContactListScreen component', () => {
-  let componentWrapper;
-  let onLoadRemapButtons;
+  let defaultProps;
   beforeEach(() => {
     jest.resetAllMocks();
-    onLoadRemapButtons = jest.fn();
-    componentWrapper = mount(
-      <ContactListScreen
-        contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
-        remapButtons={ onLoadRemapButtons }
-      />
-    );
-  });
 
-  it('should call onLoadRemapButtons on componentDidMount', () => {
-    expect(onLoadRemapButtons).toHaveBeenCalled();
+    defaultProps = {
+      contacts: [{ name: 'contact 1' }, { name: 'contact 2' }],
+      selectedIndex: 0,
+    };
   });
 
   it('should have a title', () => {
+    const componentWrapper = shallow(<ContactListComponent { ...defaultProps } />);
     expect(componentWrapper.find('.title')).toBePresent();
   });
 
-  it('should contain a GenericList component', () => {
+  it('should contain a ScrollList component', () => {
+    const componentWrapper = shallow(<ContactListComponent { ...defaultProps } />);
     expect(componentWrapper.find('ScrollList')).toBePresent();
   });
 
-  describe('getNextIndex', () => {
-    describe('when the result is between 0 and contacts.length', () => {
-      beforeEach(() => {
-        componentWrapper = mount(
-          <ContactListScreen
-            contacts={ [{ name: 'bleh' }, { name: 'bloh' }, { name: 'blah' }] }
-            remapButtons={ onLoadRemapButtons }
-            selectedIndex={ 1 }
-          />);
+  describe('button actions', () => {
+    it('should have a LEFT button config of going to Home Page', () => {
+      buttonActions(defaultProps).LEFT();
+      expect(ButtonAction.goToPage).toHaveBeenCalledWith('/');
+    });
+
+    it('should have a RIGHT button config of going to COUNTER', () => {
+      buttonActions(defaultProps).RIGHT();
+      expect(ButtonAction.goToPage).toHaveBeenCalledWith('/counter');
+    });
+
+    it('should have on SCREEN button config of going to contact view page with the selected contact', () => {
+      buttonActions({ ...defaultProps, selectedIndex: 1 }).SCREEN();
+
+      expect(ButtonAction.goToPage).toHaveBeenCalledWith({
+        pathname: '/contact-view',
+        state: { contact: { name: 'contact 2' } },
       });
-      test('it returns the new index when increased by 1', () => {
-        expect(componentWrapper.instance().getNextIndex(1)).toBe(2);
+    });
+
+    describe('TOP button', () => {
+      it('should set previous contact', () => {
+        buttonActions({ ...defaultProps, selectedIndex: 1 }).TOP();
+
+        expect(ButtonAction.goToPage).toHaveBeenCalledWith({
+          state: { selectedIndex: 0 },
+        });
+      });
+      it('should roll back to the bottom', () => {
+        buttonActions({ ...defaultProps, selectedIndex: 0 }).TOP();
+
+        expect(ButtonAction.goToPage).toHaveBeenCalledWith({
+          state: { selectedIndex: 1 },
+        });
+      });
+    });
+
+    describe('BOTTOM button', () => {
+      it('should set previous contact', () => {
+        buttonActions({ ...defaultProps, selectedIndex: 0 }).BOTTOM();
+
+        expect(ButtonAction.goToPage).toHaveBeenCalledWith({
+          state: { selectedIndex: 1 },
+        });
       });
 
-      test('it returns the new index when decreased by 1', () => {
-        expect(componentWrapper.instance().getNextIndex(-1)).toBe(0);
+      it('should roll back to the top', () => {
+        buttonActions({ ...defaultProps, selectedIndex: 1 }).BOTTOM();
+
+        expect(ButtonAction.goToPage).toHaveBeenCalledWith({
+          state: { selectedIndex: 0 },
+        });
       });
-    });
-  });
 
-  it('should have a LEFT button config of going to Home Page', () => {
-    componentWrapper.instance().buttonActions.LEFT();
-    expect(ButtonAction.goToPage).toHaveBeenCalledWith('/');
-  });
+      it('should default the selectedIndex to 0', () => {
+        buttonActions({ contacts: defaultProps.contacts }).BOTTOM();
 
-  it('should have a RIGHT button config of going to Counter page', () => {
-    componentWrapper.instance().buttonActions.RIGHT();
-    expect(ButtonAction.goToPage).toHaveBeenCalledWith('/counter');
-  });
-
-  it('should have on SCREEN button config of going to contact view page with the selected contact', () => {
-    componentWrapper = mount(
-      <ContactListScreen
-        contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
-        remapButtons={ onLoadRemapButtons }
-        selectedIndex={ 1 }
-      />
-    );
-
-    componentWrapper.instance().buttonActions.SCREEN();
-
-    expect(ButtonAction.goToPage).toHaveBeenCalledWith({
-      pathname: '/contact-view',
-      state: { contact: { name: 'bloh' } },
-    });
-  });
-
-  describe('TOP button', () => {
-    it('should set previous contact in state', () => {
-      componentWrapper = mount(
-        <ContactListScreen
-          contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
-          remapButtons={ onLoadRemapButtons }
-          selectedIndex={ 1 }
-        />
-      );
-      componentWrapper.instance().buttonActions.TOP();
-      expect(ButtonAction.goToPage).toHaveBeenCalledWith({ state: { selectedIndex: 0 } });
-    });
-
-    it('should set the selected contact to the greatest possible index when index would be negative', () => {
-      componentWrapper = mount(
-        <ContactListScreen
-          contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
-          remapButtons={ onLoadRemapButtons }
-          selectedIndex={ 0 }
-        />
-      );
-      componentWrapper.instance().buttonActions.TOP();
-      expect(ButtonAction.goToPage).toHaveBeenCalledWith({ state: { selectedIndex: 1 } });
-    });
-  });
-
-  describe('BOTTOM button', () => {
-    it('should set next contact in state', () => {
-      componentWrapper = mount(
-        <ContactListScreen
-          contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
-          remapButtons={ onLoadRemapButtons }
-          selectedIndex={ 0 }
-        />
-      );
-      componentWrapper.instance().buttonActions.BOTTOM();
-      expect(ButtonAction.goToPage).toHaveBeenCalledWith({ state: { selectedIndex: 1 } });
-    });
-
-    it('should set selected contact index to 0 when it would be more than the contact list length', () => {
-      componentWrapper = mount(
-        <ContactListScreen
-          contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
-          remapButtons={ onLoadRemapButtons }
-          selectedIndex={ 1 }
-        />
-      );
-
-      componentWrapper.instance().buttonActions.BOTTOM();
-
-      expect(ButtonAction.goToPage).toHaveBeenCalledWith({ state: { selectedIndex: 0 } });
+        expect(ButtonAction.goToPage).toHaveBeenCalledWith({
+          state: { selectedIndex: 1 },
+        });
+      });
     });
   });
 });

--- a/src/app/pages/ContactListScreen/ContactListScreen.spec.js
+++ b/src/app/pages/ContactListScreen/ContactListScreen.spec.js
@@ -31,6 +31,26 @@ describe('ContactListScreen component', () => {
     expect(componentWrapper.find('ScrollList')).toBePresent();
   });
 
+  describe('getNextIndex', () => {
+    describe('when the result is between 0 and contacts.length', () => {
+      beforeEach(() => {
+        componentWrapper = mount(
+          <ContactListScreen
+            contacts={ [{ name: 'bleh' }, { name: 'bloh' }, { name: 'blah' }] }
+            remapButtons={ onLoadRemapButtons }
+            selectedIndex={ 1 }
+          />);
+      });
+      test('it returns the new index when increased by 1', () => {
+        expect(componentWrapper.instance().getNextIndex(1)).toBe(2);
+      });
+
+      test('it returns the new index when decreased by 1', () => {
+        expect(componentWrapper.instance().getNextIndex(-1)).toBe(0);
+      });
+    });
+  });
+
   it('should have a LEFT button config of going to Home Page', () => {
     componentWrapper.instance().buttonActions.LEFT();
     expect(ButtonAction.goToPage).toHaveBeenCalledWith('/');
@@ -71,7 +91,7 @@ describe('ContactListScreen component', () => {
       expect(ButtonAction.goToPage).toHaveBeenCalledWith({ state: { selectedIndex: 0 } });
     });
 
-    it('should set the selected contact index in negative', () => {
+    it('should set the selected contact to the greatest possible index when index would be negative', () => {
       componentWrapper = mount(
         <ContactListScreen
           contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
@@ -80,7 +100,7 @@ describe('ContactListScreen component', () => {
         />
       );
       componentWrapper.instance().buttonActions.TOP();
-      expect(ButtonAction.goToPage).not.toHaveBeenCalled();
+      expect(ButtonAction.goToPage).toHaveBeenCalledWith({ state: { selectedIndex: 1 } });
     });
   });
 
@@ -97,7 +117,7 @@ describe('ContactListScreen component', () => {
       expect(ButtonAction.goToPage).toHaveBeenCalledWith({ state: { selectedIndex: 1 } });
     });
 
-    it('should set selected contact index to be more than the contact list length', () => {
+    it('should set selected contact index to 0 when it would be more than the contact list length', () => {
       componentWrapper = mount(
         <ContactListScreen
           contacts={ [{ name: 'bleh' }, { name: 'bloh' }] }
@@ -108,7 +128,7 @@ describe('ContactListScreen component', () => {
 
       componentWrapper.instance().buttonActions.BOTTOM();
 
-      expect(ButtonAction.goToPage).not.toHaveBeenCalled();
+      expect(ButtonAction.goToPage).toHaveBeenCalledWith({ state: { selectedIndex: 0 } });
     });
   });
 });

--- a/src/app/pages/ContactListScreen/contact_list.css
+++ b/src/app/pages/ContactListScreen/contact_list.css
@@ -4,6 +4,8 @@
 
 .contact-screen .contacts-list ul {
   padding-bottom: 5px;
-
 }
 
+.contact-screen li.selected {
+  background-color: rgba(153, 153, 153, 0.21);
+}

--- a/src/app/pages/ContactViewScreen/ContactViewScreen.js
+++ b/src/app/pages/ContactViewScreen/ContactViewScreen.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import {
+  string,
+  arrayOf,
+  number,
+  shape,
+} from 'prop-types';
+import { withRouter } from 'react-router';
+import ButtonAction from '../../../framework/util/ButtonAction';
+import WithButtonConfigs from '../../../framework/containers/WithButtonConfigs';
+
+export const ContactViewScreenComponent = ({ contacts, match }) => {
+  const selectedContact = contacts[match.params.selectedContactIndex];
+  return (
+    <div className='contact'>
+      <h2> Yay here is your contact </h2>
+      <div className='name'>
+        <b>Name</b>: {selectedContact.name}
+      </div>
+    </div>
+  );
+};
+
+ContactViewScreenComponent.propTypes = {
+  match: shape({ params: shape({ selectedContactIndex: number.isRequired }) }).isRequired,
+  contacts: arrayOf(shape({
+    name: string,
+    phone: string,
+    address: string,
+  })).isRequired,
+};
+
+export const ContactViewScreenButtons = {
+  LEFT: () => ButtonAction.goToPage({ pathname: '/counter', state: { number: 5 } }),
+  RIGHT: () => ButtonAction.goToPage('/contacts'),
+  TOP: () => ButtonAction.scrollUp(),
+  BOTTOM: () => ButtonAction.scrollDown(),
+};
+
+export default withRouter(WithButtonConfigs(ContactViewScreenComponent, ContactViewScreenButtons));

--- a/src/app/pages/ContactViewScreen/ContactViewScreen.js
+++ b/src/app/pages/ContactViewScreen/ContactViewScreen.js
@@ -1,33 +1,29 @@
 import React from 'react';
 import {
   string,
-  arrayOf,
-  number,
   shape,
 } from 'prop-types';
 import { withRouter } from 'react-router';
 import ButtonAction from '../../../framework/util/ButtonAction';
 import WithButtonConfigs from '../../../framework/containers/WithButtonConfigs';
 
-export const ContactViewScreenComponent = ({ contacts, match }) => {
-  const selectedContact = contacts[match.params.selectedContactIndex];
+export const ContactViewScreenComponent = ({ contact }) => {
   return (
     <div className='contact'>
       <h2> Yay here is your contact </h2>
       <div className='name'>
-        <b>Name</b>: {selectedContact.name}
+        <b>Name</b>: {contact.name}
       </div>
     </div>
   );
 };
 
 ContactViewScreenComponent.propTypes = {
-  match: shape({ params: shape({ selectedContactIndex: number.isRequired }) }).isRequired,
-  contacts: arrayOf(shape({
+  contact: shape({
     name: string,
     phone: string,
     address: string,
-  })).isRequired,
+  }).isRequired,
 };
 
 export const ContactViewScreenButtons = {

--- a/src/app/pages/ContactViewScreen/ContactViewScreen.spec.js
+++ b/src/app/pages/ContactViewScreen/ContactViewScreen.spec.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ButtonAction from '../../../framework/util/ButtonAction';
+import { ContactViewScreenComponent as ContactViewScreen, ContactViewScreenButtons } from './ContactViewScreen';
+
+jest.mock('../../../framework/util/ButtonAction');
+
+describe('ContactViewScreen ', () => {
+  let componentWrapper;
+  const mockContacts = [{ name: 'contact 0' }, { name: 'MeMeMEEE' }];
+  const mockRouterMatchObj = { params: { selectedContactIndex: 1 } };
+
+  beforeEach(() => {
+    componentWrapper = shallow(
+      <ContactViewScreen contacts={ mockContacts } match={ mockRouterMatchObj } />
+    );
+  });
+
+  it('should have a header', () => {
+    expect(componentWrapper.find('h2')).toBePresent();
+  });
+
+  it('should display the required contact based on the url path', () => {
+    expect(componentWrapper.find('.name')).toHaveText('Name: MeMeMEEE');
+  });
+
+  test('it should have a LEFT button config of going to Counter Page with an initial number value of 5', () => {
+    ContactViewScreenButtons.LEFT();
+    expect(ButtonAction.goToPage).toHaveBeenCalledWith({ pathname: '/counter', state: { number: 5 } });
+  });
+
+  test('it should have a RIGHT button config of going to contactList page', () => {
+    ContactViewScreenButtons.RIGHT();
+    expect(ButtonAction.goToPage).toHaveBeenCalledWith('/contacts');
+  });
+
+  test('it should have a TOP button config of scrolling page up', () => {
+    ContactViewScreenButtons.TOP();
+    expect(ButtonAction.scrollUp).toHaveBeenCalled();
+  });
+
+  test('it should have a BOTTOM button config of scrolling page down', () => {
+    ContactViewScreenButtons.BOTTOM();
+    expect(ButtonAction.scrollDown).toHaveBeenCalled();
+  });
+});

--- a/src/app/pages/ContactViewScreen/ContactViewScreen.spec.js
+++ b/src/app/pages/ContactViewScreen/ContactViewScreen.spec.js
@@ -7,12 +7,11 @@ jest.mock('../../../framework/util/ButtonAction');
 
 describe('ContactViewScreen ', () => {
   let componentWrapper;
-  const mockContacts = [{ name: 'contact 0' }, { name: 'MeMeMEEE' }];
-  const mockRouterMatchObj = { params: { selectedContactIndex: 1 } };
+  const mockContact = { name: 'MeMeMEEE' };
 
   beforeEach(() => {
     componentWrapper = shallow(
-      <ContactViewScreen contacts={ mockContacts } match={ mockRouterMatchObj } />
+      <ContactViewScreen contact={ mockContact } />
     );
   });
 

--- a/src/framework/components/GenericList/GenericList.jsx
+++ b/src/framework/components/GenericList/GenericList.jsx
@@ -7,6 +7,7 @@ const GenericList = (props) => {
     liClassName,
     items,
     listItem,
+    selectedItemIndex,
   } = props;
 
   return (
@@ -14,7 +15,7 @@ const GenericList = (props) => {
       {items.map((item, index) => (
         <li
           key={ `generic-list-${ index + 1 }` }
-          className={ liClassName }
+          className={ `${ liClassName } ${ index === selectedItemIndex ? 'selected' : '' }` }
         >
           {listItem(item)}
         </li>
@@ -26,6 +27,7 @@ const GenericList = (props) => {
 GenericList.propTypes = {
   className: PropTypes.string,
   liClassName: PropTypes.string,
+  selectedItemIndex: PropTypes.number,
   items: PropTypes.arrayOf(PropTypes.any).isRequired,
   listItem: PropTypes.func.isRequired,
 };
@@ -33,6 +35,7 @@ GenericList.propTypes = {
 GenericList.defaultProps = {
   className: 'generic-list',
   liClassName: '',
+  selectedItemIndex: 0,
   items: [],
 };
 

--- a/src/framework/components/ScreenLayout/ScreenLayout.spec.js
+++ b/src/framework/components/ScreenLayout/ScreenLayout.spec.js
@@ -32,5 +32,14 @@ describe('ScreenLayout component', () => {
     test("Components with and without a 'path' prop are still rendered at some point", () => {
       expect(renderedScreen.find(Mock).length).toBe(2);
     });
+
+    test('the test coverage goes to 100% when rendered with the default onClick', () => {
+      renderedScreen = mount(
+        <ScreenLayout>
+          <Mock /><Mock />
+        </ScreenLayout>);
+
+      expect(renderedScreen.props().onClick());
+    });
   });
 });

--- a/src/framework/components/ScrollList/ScrollList.jsx
+++ b/src/framework/components/ScrollList/ScrollList.jsx
@@ -10,7 +10,11 @@ const ScrollList = ({ labels, selectedIndex, itemHeight }) => {
     } }
     >
       {
-      ['', '', ...labels, '', '']
+        [
+          ...labels.slice(-2),
+          ...labels,
+          ...labels.slice(0, 2),
+        ]
         .slice(selectedIndex, selectedIndex + 5)
         .map((label, index) => (
           <li

--- a/src/framework/components/ScrollList/ScrollList.jsx
+++ b/src/framework/components/ScrollList/ScrollList.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ScrollList = ({ labels, selectedIndex, itemHeight }) => {
+  return (
+    <ul style={ {
+      listStyleType: 'none',
+      margin: 0,
+      padding: 0,
+    } }
+    >
+      {
+      ['', '', ...labels, '', '']
+        .slice(selectedIndex, selectedIndex + 5)
+        .map((label, index) => (
+          <li
+            key={ `scroll-list-item-${ label + index }` }
+            style={ {
+              height: itemHeight,
+              verticalAlign: 'middle',
+              fontSize: index === 2 ? 20 : null,
+
+            } }
+            className={ `scroll-item ${ index === 2 ? 'selected' : '' }` }
+          >
+            { label }
+          </li>
+        ))
+    }
+    </ul>
+  );
+};
+
+ScrollList.propTypes = {
+  labels: PropTypes.arrayOf(PropTypes.string).isRequired,
+  selectedIndex: PropTypes.number,
+  itemHeight: PropTypes.number,
+};
+
+ScrollList.defaultProps = {
+  selectedIndex: 0,
+  itemHeight: 30,
+};
+
+export default ScrollList;

--- a/src/framework/components/ScrollList/ScrollList.spec.jsx
+++ b/src/framework/components/ScrollList/ScrollList.spec.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ScrollList from './ScrollList';
+
+describe('ScrollList', () => {
+  let items;
+  beforeEach(() => {
+    items = ['item 1', 'item 2', 'item 3', 'item 4', 'item 5'];
+  });
+
+  describe('when the 1st item is selected', () => {
+    it('should display the 1st 3 items', () => {
+      const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 0 } />);
+      expect(wrapper).toIncludeText('item 1');
+      expect(wrapper).toIncludeText('item 2');
+      expect(wrapper).toIncludeText('item 3');
+    });
+
+    it('should not display the last 2 items', () => {
+      const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 0 } />);
+      expect(wrapper).not.toIncludeText('item 4');
+      expect(wrapper).not.toIncludeText('item 5');
+    });
+
+    it('should have the selected class on the 1st item', () => {
+      const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 0 } />);
+      expect(wrapper.find('.selected')).toIncludeText('item 1');
+    });
+  });
+
+  describe('when the 4th item is selected', () => {
+    it('should display the last 4 items', () => {
+      const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 3 } />);
+      expect(wrapper).toIncludeText('item 2');
+      expect(wrapper).toIncludeText('item 3');
+      expect(wrapper).toIncludeText('item 4');
+      expect(wrapper).toIncludeText('item 5');
+    });
+
+    it('should not display the last 2 items', () => {
+      const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 3 } />);
+      expect(wrapper).not.toIncludeText('item 1');
+    });
+
+    it('should have the selected class on the 1st item', () => {
+      const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 3 } />);
+      expect(wrapper.find('.selected')).toIncludeText('item 4');
+    });
+  });
+});

--- a/src/framework/components/ScrollList/ScrollList.spec.jsx
+++ b/src/framework/components/ScrollList/ScrollList.spec.jsx
@@ -5,21 +5,18 @@ import ScrollList from './ScrollList';
 describe('ScrollList', () => {
   let items;
   beforeEach(() => {
-    items = ['item 1', 'item 2', 'item 3', 'item 4', 'item 5'];
+    items = ['item 1', 'item 2', 'item 3', 'item 4', 'item 5', 'item 6'];
   });
 
   describe('when the 1st item is selected', () => {
-    it('should display the 1st 3 items', () => {
+    it('should display the last 2 and 1st 3 items', () => {
       const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 0 } />);
-      expect(wrapper).toIncludeText('item 1');
-      expect(wrapper).toIncludeText('item 2');
-      expect(wrapper).toIncludeText('item 3');
+      expect(wrapper).toIncludeText('item 5item 6item 1item 2item 3');
     });
 
-    it('should not display the last 2 items', () => {
+    it('should not display item 4', () => {
       const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 0 } />);
       expect(wrapper).not.toIncludeText('item 4');
-      expect(wrapper).not.toIncludeText('item 5');
     });
 
     it('should have the selected class on the 1st item', () => {
@@ -30,21 +27,18 @@ describe('ScrollList', () => {
 
   describe('when the 4th item is selected', () => {
     it('should display the last 4 items', () => {
-      const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 3 } />);
-      expect(wrapper).toIncludeText('item 2');
-      expect(wrapper).toIncludeText('item 3');
-      expect(wrapper).toIncludeText('item 4');
-      expect(wrapper).toIncludeText('item 5');
+      const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 4 } />);
+      expect(wrapper).toIncludeText('item 3item 4item 5item 6item 1');
     });
 
     it('should not display the last 2 items', () => {
-      const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 3 } />);
-      expect(wrapper).not.toIncludeText('item 1');
+      const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 4 } />);
+      expect(wrapper).not.toIncludeText('item 2');
     });
 
     it('should have the selected class on the 1st item', () => {
-      const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 3 } />);
-      expect(wrapper.find('.selected')).toIncludeText('item 4');
+      const wrapper = shallow(<ScrollList labels={ items } selectedIndex={ 4 } />);
+      expect(wrapper.find('.selected')).toIncludeText('item 5');
     });
   });
 });

--- a/src/framework/containers/WithButtonConfigs.js
+++ b/src/framework/containers/WithButtonConfigs.js
@@ -3,6 +3,12 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { remapButtons } from '../actions/ButtonAction';
 
+// TODO: we could use lodash isFunction instead of this.
+function isFunction(functionToCheck) {
+  const getType = {};
+  return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
+}
+
 const ButtonConfigsHOC = (WrappedComponent) => {
   class Wrapper extends Component {
     componentDidMount() {
@@ -23,20 +29,36 @@ const ButtonConfigsHOC = (WrappedComponent) => {
 
 function WithButtonConfigs(component, buttonConfigs) {
   const mapStateToProps = (state, ownProps) => {
-    return { ...ownProps, ...((state.router || {}).location || {}).state ? state.router.location.state : {} };
+    return {
+      ...ownProps,
+      ...((state.router || {}).location || {}).state ? state.router.location.state : {},
+    };
   };
+
 
   const mapDispatchToProps = (dispatch) => {
     return {
-      remapButtons: (newButtonConfigs = buttonConfigs) => {
-        dispatch(remapButtons(newButtonConfigs));
+      dispatchRemapButtons: buttonConfig => dispatch(remapButtons(buttonConfig)),
+    };
+  };
+
+  const mergeProps = (stateProps, dispatchProps, ownProps) => {
+    return {
+      ...ownProps,
+      ...stateProps,
+      remapButtons: (newButtonConfig = buttonConfigs) => {
+        const buttonActions = isFunction(newButtonConfig) ?
+          newButtonConfig({ ...stateProps, ...ownProps }) :
+          newButtonConfig;
+        dispatchProps.dispatchRemapButtons(buttonActions);
       },
     };
   };
 
   return connect(
     mapStateToProps,
-    mapDispatchToProps
+    mapDispatchToProps,
+    mergeProps
   )(ButtonConfigsHOC(component));
 }
 

--- a/src/framework/containers/WithButtonConfigs.spec.js
+++ b/src/framework/containers/WithButtonConfigs.spec.js
@@ -45,6 +45,24 @@ describe('WithButtonConfigs', () => {
     expect(store.dispatch).toHaveBeenCalledWith(expectedDispatchAction);
   });
 
+  it('should call the buttonMappings as a function if it is a isFunction', () => {
+    const buttonMappingFunction = jest.fn();
+    buttonMappingFunction.mockReturnValue(buttonMappings);
+    ConnectedComponent = WithButtonConfigs(mockedComponent, buttonMappingFunction);
+    buttonWrapper = mount(
+      <Provider store={ store }>
+        <ConnectedComponent someProp />
+      </Provider>
+    );
+
+    const expectedDispatchAction = {
+      type: ACTION_TYPES.BUTTON_REMAP,
+      remapedButtons: buttonMappings,
+    };
+    expect(buttonMappingFunction).toHaveBeenCalledWith({ someProp: true });
+    expect(store.dispatch).toHaveBeenCalledWith(expectedDispatchAction);
+  });
+
   it('should assign any values in the components location object to props', () => {
     const fakeNav = {
       router: {

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import WatchApp from './framework';
 const pages = [
   { path: '/', Component: HomeScreen },
   { path: '/contacts', Component: ContactScreen, props: { contacts } },
-  { path: '/contact/:selectedContactIndex', Component: ContactViewScreen, props: { contacts } },
+  { path: '/contact-view', Component: ContactViewScreen },
   { path: '/counter', Component: CounterScreen },
   { path: '/notfound', Component: NotFoundScreen },
 ];

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import HomeScreen from './app/pages/HomeScreen/HomeScreen';
 import CounterScreen from './app/pages/CounterScreen/CounterScreen';
 import ContactScreen from './app/pages/ContactListScreen/ContactListScreen';
+import ContactViewScreen from './app/pages/ContactViewScreen/ContactViewScreen';
 import NotFoundScreen from './app/pages/NotFoundScreen/NotFoundScreen';
 import contacts from './app/data/contacts.json';
 import WatchApp from './framework';
@@ -11,6 +12,7 @@ import WatchApp from './framework';
 const pages = [
   { path: '/', Component: HomeScreen },
   { path: '/contacts', Component: ContactScreen, props: { contacts } },
+  { path: '/contact/:selectedContactIndex', Component: ContactViewScreen, props: { contacts } },
   { path: '/counter', Component: CounterScreen },
   { path: '/notfound', Component: NotFoundScreen },
 ];


### PR DESCRIPTION
Here is a quick refactor of https://github.com/twlevelup/watch_edition_react/pull/28 

There was a bit of a discussion on the slack channel around trying to utilise the goToPage({ state: blah }) functionality.

I also created a new list component that scrolls similar to IOS pickers as there was an issue with how we were doing scrolling with this alternate solution

I made this a 2nd pull request so both could be compared.